### PR TITLE
[infra] Self-validating + self-merging workflow PRs

### DIFF
--- a/.github/workflows/agent-autonomy.yml
+++ b/.github/workflows/agent-autonomy.yml
@@ -75,6 +75,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create PR if state changed
+        id: create_pr
         run: |
           git diff --quiet && echo "No changes to commit" && exit 0
 
@@ -85,10 +86,38 @@ jobs:
           git add -A
           git commit -m "[action] Agent dispatch — $(date -u '+%Y-%m-%d %H:%M UTC')"
           git push --set-upstream origin "$BRANCH"
-          gh pr create \
+          PR_URL=$(gh pr create \
             --title "[action] Agent dispatch activity" \
-            --body "Automated agent activity via unified dispatch. Validated by agent-action pipeline before merge." \
+            --body "Automated agent activity via unified dispatch." \
             --base main \
-            --head "$BRANCH"
+            --head "$BRANCH")
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$(echo $PR_URL | grep -o '[0-9]*$')" >> "$GITHUB_OUTPUT"
+          echo "has_pr=true" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate state changes
+        id: validate
+        if: steps.create_pr.outputs.has_pr == 'true'
+        run: python scripts/validate_action.py
+        continue-on-error: true
+
+      - name: PII scan
+        id: pii
+        if: steps.create_pr.outputs.has_pr == 'true'
+        run: python scripts/pii_scan.py state/ feed/
+        continue-on-error: true
+
+      - name: Merge or flag PR
+        if: steps.create_pr.outputs.has_pr == 'true'
+        run: |
+          if [ "${{ steps.validate.outcome }}" = "success" ] && [ "${{ steps.pii.outcome }}" = "success" ]; then
+            echo "✅ Validation passed — merging PR #${{ steps.create_pr.outputs.pr_number }}"
+            gh pr merge ${{ steps.create_pr.outputs.pr_number }} --squash --delete-branch
+          else
+            echo "❌ Validation failed — leaving PR open for review"
+            gh pr comment ${{ steps.create_pr.outputs.pr_number }} --body "❌ **Self-validation failed.** Validate: ${{ steps.validate.outcome }}, PII: ${{ steps.pii.outcome }}. Needs manual review."
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/architect-explore.yml
+++ b/.github/workflows/architect-explore.yml
@@ -60,6 +60,7 @@ jobs:
         run: python scripts/pii_scan.py state/ feed/
 
       - name: Create PR if state changed
+        id: create_pr
         if: ${{ github.event.inputs.dry_run != 'true' }}
         run: |
           git diff --quiet && echo "No changes to commit" && exit 0
@@ -71,10 +72,32 @@ jobs:
           git add -A
           git commit -m "[action] architect-001 explores — $(date -u '+%Y-%m-%d %H:%M UTC')"
           git push --set-upstream origin "$BRANCH"
-          gh pr create \
+          PR_URL=$(gh pr create \
             --title "[action] Architect exploration" \
-            --body "Automated architect exploration. Validated by agent-action pipeline before merge." \
+            --body "Automated architect exploration." \
             --base main \
-            --head "$BRANCH"
+            --head "$BRANCH")
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$(echo $PR_URL | grep -o '[0-9]*$')" >> "$GITHUB_OUTPUT"
+          echo "has_pr=true" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate state changes
+        id: validate
+        if: steps.create_pr.outputs.has_pr == 'true'
+        run: python scripts/validate_action.py
+        continue-on-error: true
+
+      - name: Merge or flag PR
+        if: steps.create_pr.outputs.has_pr == 'true'
+        run: |
+          if [ "${{ steps.validate.outcome }}" = "success" ]; then
+            echo "✅ Validation passed — merging PR #${{ steps.create_pr.outputs.pr_number }}"
+            gh pr merge ${{ steps.create_pr.outputs.pr_number }} --squash --delete-branch
+          else
+            echo "❌ Validation failed — leaving PR open for review"
+            gh pr comment ${{ steps.create_pr.outputs.pr_number }} --body "❌ **Self-validation failed.** Needs manual review."
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/game-tick.yml
+++ b/.github/workflows/game-tick.yml
@@ -35,6 +35,7 @@ jobs:
         run: python scripts/game_tick.py
 
       - name: Create PR if state changed
+        id: create_pr
         run: |
           git diff --quiet && echo "No changes to commit" && exit 0
 
@@ -45,10 +46,38 @@ jobs:
           git add -A
           git commit -m "[tick] World update — $(date -u '+%Y-%m-%d %H:%M UTC')"
           git push --set-upstream origin "$BRANCH"
-          gh pr create \
+          PR_URL=$(gh pr create \
             --title "[tick] World update" \
-            --body "Automated game tick. Validated by agent-action pipeline before merge." \
+            --body "Automated game tick." \
             --base main \
-            --head "$BRANCH"
+            --head "$BRANCH")
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$(echo $PR_URL | grep -o '[0-9]*$')" >> "$GITHUB_OUTPUT"
+          echo "has_pr=true" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate state changes
+        id: validate
+        if: steps.create_pr.outputs.has_pr == 'true'
+        run: python scripts/validate_action.py
+        continue-on-error: true
+
+      - name: PII scan
+        id: pii
+        if: steps.create_pr.outputs.has_pr == 'true'
+        run: python scripts/pii_scan.py state/ feed/
+        continue-on-error: true
+
+      - name: Merge or flag PR
+        if: steps.create_pr.outputs.has_pr == 'true'
+        run: |
+          if [ "${{ steps.validate.outcome }}" = "success" ] && [ "${{ steps.pii.outcome }}" = "success" ]; then
+            echo "✅ Validation passed — merging PR #${{ steps.create_pr.outputs.pr_number }}"
+            gh pr merge ${{ steps.create_pr.outputs.pr_number }} --squash --delete-branch
+          else
+            echo "❌ Validation failed — leaving PR open for review"
+            gh pr comment ${{ steps.create_pr.outputs.pr_number }} --body "❌ **Self-validation failed.** Validate: ${{ steps.validate.outcome }}, PII: ${{ steps.pii.outcome }}. Needs manual review."
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/world-growth.yml
+++ b/.github/workflows/world-growth.yml
@@ -155,6 +155,7 @@ jobs:
         run: python scripts/generate_dashboard.py
 
       - name: Create PR if state changed
+        id: create_pr
         if: ${{ github.event.inputs.dry_run != 'true' }}
         run: |
           git diff --quiet && echo "No changes to commit" && exit 0
@@ -166,10 +167,38 @@ jobs:
           git add -A
           git commit -m "[heartbeat] World pulse — $(date -u '+%Y-%m-%d %H:%M UTC')"
           git push --set-upstream origin "$BRANCH"
-          gh pr create \
+          PR_URL=$(gh pr create \
             --title "[heartbeat] World pulse" \
-            --body "Automated world heartbeat. Validated by agent-action pipeline before merge." \
+            --body "Automated world heartbeat." \
             --base main \
-            --head "$BRANCH"
+            --head "$BRANCH")
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$(echo $PR_URL | grep -o '[0-9]*$')" >> "$GITHUB_OUTPUT"
+          echo "has_pr=true" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate state changes
+        id: validate
+        if: steps.create_pr.outputs.has_pr == 'true'
+        run: python scripts/validate_action.py
+        continue-on-error: true
+
+      - name: PII scan
+        id: pii
+        if: steps.create_pr.outputs.has_pr == 'true'
+        run: python scripts/pii_scan.py state/ feed/
+        continue-on-error: true
+
+      - name: Merge or flag PR
+        if: steps.create_pr.outputs.has_pr == 'true'
+        run: |
+          if [ "${{ steps.validate.outcome }}" = "success" ] && [ "${{ steps.pii.outcome }}" = "success" ]; then
+            echo "✅ Validation passed — merging PR #${{ steps.create_pr.outputs.pr_number }}"
+            gh pr merge ${{ steps.create_pr.outputs.pr_number }} --squash --delete-branch
+          else
+            echo "❌ Validation failed — leaving PR open for review"
+            gh pr comment ${{ steps.create_pr.outputs.pr_number }} --body "❌ **Self-validation failed.** Validate: ${{ steps.validate.outcome }}, PII: ${{ steps.pii.outcome }}. Needs manual review."
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## The Bug
PRs created by workflows using `GITHUB_TOKEN` never triggered `agent-action.yml` — this is a GitHub anti-recursion safety rule. **Every autonomous PR sat open forever.** The world has never actually evolved on its own.

## The Fix
Each state-writing workflow now validates and merges its own PR in the same run:
1. Create branch → commit → push → create PR *(existing)*
2. `python scripts/validate_action.py` *(new)*
3. `python scripts/pii_scan.py` *(new)*
4. If both pass → `gh pr merge --squash --delete-branch` *(new)*
5. If either fails → comment error, leave PR open for human review *(new)*

## Affected Workflows
- **agent-autonomy.yml** — every 30 min agent dispatch
- **game-tick.yml** — every 5 min world tick
- **world-growth.yml** — every 4 hours heartbeat
- **architect-explore.yml** — every 4 hours exploration

## Also
- Closed 6 orphan PRs (#93, #97, #99, #100, #101, #103) that were stuck forever
- Added regression test: `test_pr_creating_workflows_self_merge` (40 tests total)
- `agent-action.yml` unchanged — still handles external/human PRs that DO trigger it